### PR TITLE
Fix unknown property error for latest BOSH

### DIFF
--- a/jobs/statsd/spec
+++ b/jobs/statsd/spec
@@ -16,3 +16,6 @@ properties:
   statsd.deleteIdleStats:
     description: Don't send values to graphite for inactive counters, sets, gauges, or timers.
     default: false
+  statsd.carbon_cache_line_receiver_port:
+    description: Port the carbon cache line receiver listens on.
+    default: 2003

--- a/jobs/statsd/templates/config/config.js.erb
+++ b/jobs/statsd/templates/config/config.js.erb
@@ -99,7 +99,7 @@ Optional Variables:
 
 */
 {
-  graphitePort: <%= p('carbon.cache.line_receiver_port') %>
+  graphitePort: <%= p('statsd.carbon_cache_line_receiver_port') %>
 , graphiteHost: "127.0.0.1"
 , port: <%= p('statsd.port') %>
 , backends: [ "./backends/graphite" ]


### PR DESCRIPTION
Recent BOSH (tested with 256.2) prevents a job template to access a variable that is not in its spec file. This is probably because of [BOSH manifest v2](https://bosh.io/docs/manifest-v2.html). It's an issue for `statsd` that tries to access property `carbon.cache.line_receiver_port` in carbon.

Here we copy the carbon variable to the statsd spec file to deal with this case and rename it as `statsd.carbon_cache_line_receiver_port`.

This is a breaking change if a user has a non default value for `carbon.cache.line_receiver_port`.
