### PR TITLE
Fix graphite-web slow start

### DIFF
--- a/jobs/graphite-web/templates/bin/graphite-web_ctl.erb
+++ b/jobs/graphite-web/templates/bin/graphite-web_ctl.erb
@@ -25,7 +25,8 @@ case $1 in
     # Set file permissions
     chown -RH vcap:vcap /var/vcap/sys/log/graphite-web
     chown -RH vcap:vcap /var/vcap/sys/run/graphite-web
-    chown -RH vcap:vcap /var/vcap/store/graphite
+    chown vcap:vcap /var/vcap/store/graphite
+    chown vcap:vcap /var/vcap/store/graphite/storage
     chown vcap:vcap /var/vcap/store/graphite/storage/index
     chown vcap:vcap /var/vcap/store/graphite/storage/rrd
     chown vcap:vcap /var/vcap/store/graphite/storage/whisper


### PR DESCRIPTION
The recursive chown on /var/vcap/store/graphite becomes very slow once we collect a large number of metrics and graphite-web fails to start because it exceeds the timeout.

It's actually not needed because all the new files are created as user vcap by carbon. By replacing the recursive chown by individual chown on the top directories we avoid this issue.
