### PR TITLE
Fix carbon slow start

### DIFF
--- a/jobs/carbon/templates/bin/carbon_ctl.erb
+++ b/jobs/carbon/templates/bin/carbon_ctl.erb
@@ -21,7 +21,7 @@ case $1 in
     # Set file permissions
     chown -RH vcap:vcap /var/vcap/sys/log/carbon
     chown -RH vcap:vcap /var/vcap/sys/run/carbon
-    chown -RH vcap:vcap /var/vcap/store/graphite
+    chown -H vcap:vcap /var/vcap/store/graphite
 
     <% if p('carbon.prune_delay') != -1 %>
     ln -sf /var/vcap/jobs/carbon/bin/prune_metrics /etc/cron.daily/prune_metrics


### PR DESCRIPTION
Same issue as the one fixed in 0fc12c6 but in carbon this time.

The recursive `chown` in the start script becomes very slow when there are lots of metrics. It is not needed, we replace it with simple `chown` on the top directory.
