### PR TITLE
WIP: Implement logic to send service logs to syslog

### DIFF
--- a/jobs/carbon/spec
+++ b/jobs/carbon/spec
@@ -19,6 +19,9 @@ templates:
   config/whitelist.conf.erb: conf/whitelist.conf
 
 properties:
+  carbon.cache.log_to_syslog:
+    description: Set this to True to enable logging to syslog.
+    default: False
   carbon.cache.enable_log_rotation:
     description: Set this to True to enable daily log rotation.
     default: True

--- a/jobs/carbon/templates/bin/carbon_ctl.erb
+++ b/jobs/carbon/templates/bin/carbon_ctl.erb
@@ -29,10 +29,19 @@ case $1 in
     rm -f /etc/cron.daily/prune_metrics
     <% end %>
 
+    <% if p('carbon.cache.log_to_syslog') %>
+    exec chpst -u vcap:vcap python /var/vcap/packages/carbon/bin/carbon-cache.py \
+      --config=/var/vcap/packages/carbon/conf/carbon.conf \
+      --debug \
+      start \
+      1> >(tee -a /var/vcap/sys/log/carbon/carbon.stdout.log | logger -t vcap.carbon.stdout ) \
+      2> >(tee -a /var/vcap/sys/log/carbon/carbon.stderr.log | logger -t vcap.carbon.stderr ) &
+    <% else %>
     exec chpst -u vcap:vcap python /var/vcap/packages/carbon/bin/carbon-cache.py \
       --config=/var/vcap/packages/carbon/conf/carbon.conf start \
       1>> /var/vcap/sys/log/carbon/carbon_ctl.stdout.log \
       2>> /var/vcap/sys/log/carbon/carbon_ctl.stderr.log
+    <% end %>
     ;;
 
   stop)

--- a/jobs/graphite-web/spec
+++ b/jobs/graphite-web/spec
@@ -33,6 +33,9 @@ templates:
   config/graphite-vhost.conf.erb: conf/graphite-vhost.conf
 
 properties:
+  graphite-web.log_to_syslog:
+    description: Set this to True to enable error logging to syslog.
+    default: False
 
   graphite-web.secret_key:
     description: Set this to a long, random unique string to use as a secret key for this install.

--- a/jobs/graphite-web/templates/config/httpd.conf.erb
+++ b/jobs/graphite-web/templates/config/httpd.conf.erb
@@ -50,7 +50,11 @@ WSGISocketPrefix run/wsgi
 </Files>
 
 LogLevel warn
+<% if p('graphite-web.log_to_syslog') %>
+ErrorLog "|$ tee -a /var/vcap/sys/log/graphite-web/default_httpd_error.log | logger -t vcap.graphite-web"
+<% else %>
 ErrorLog "/var/vcap/sys/log/graphite-web/default_httpd_error.log"
+<% end %>
 
 <IfModule log_config_module>
     LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined

--- a/jobs/statsd/spec
+++ b/jobs/statsd/spec
@@ -19,3 +19,6 @@ properties:
   statsd.carbon_cache_line_receiver_port:
     description: Port the carbon cache line receiver listens on.
     default: 2003
+  statsd.log_to_syslog:
+    description: Set this to True to enable logging to syslog.
+    default: False

--- a/jobs/statsd/templates/bin/statsd_ctl.erb
+++ b/jobs/statsd/templates/bin/statsd_ctl.erb
@@ -17,6 +17,18 @@ case $1 in
     chown -H vcap:vcap /var/vcap/sys/log/statsd
     chown -H vcap:vcap /var/vcap/sys/run/statsd
 
+<% if p('statsd.log_to_syslog') %>
+    start-stop-daemon --start --quiet -m \
+      --pidfile /var/vcap/sys/run/statsd/statsd.pid \
+      --startas /var/vcap/packages/node/bin/node \
+      --chuid vcap:vcap \
+      --background \
+      --no-close \
+      --chdir /var/vcap/packages/statsd \
+      -- /var/vcap/packages/statsd/stats.js /var/vcap/packages/statsd/localConfig.js \
+      1> >(tee -a /var/vcap/sys/log/statsd/statsd.stdout.log | logger -t vcap.statsd.stdout ) \
+      2> >(tee -a /var/vcap/sys/log/statsd/statsd.stderr.log | logger -t vcap.statsd.stderr )
+<% else %>
     start-stop-daemon --start --quiet -m \
       --pidfile /var/vcap/sys/run/statsd/statsd.pid \
       --startas /var/vcap/packages/node/bin/node \
@@ -27,6 +39,7 @@ case $1 in
       -- /var/vcap/packages/statsd/stats.js /var/vcap/packages/statsd/localConfig.js \
       1>> /var/vcap/sys/log/statsd/statsd_ctl.stdout.log \
       2>> /var/vcap/sys/log/statsd/statsd_ctl.stderr.log
+<% end %>
     ;;
 
   stop)


### PR DESCRIPTION
# Motivation

Several of the CF and Diego platform services send logs to the local syslog, tagged as `vcap.*`. . The [metron agent from loggregrator configures the local syslog to send the logs to metron](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec#L29) so that later can be sent to a centralised logging service. 

In some cases it is the service application itself who sends the logs to syslog, but it seems to be a common pattern across CF and Diego services to [let the service log to stdout/stderr, and redirect that output to local files or syslog](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb#L91) using the [`logger` command](http://linux.die.net/man/1/logger). 

Not all the services implement this feature, and instead they only log to local files. In order to centralise all the logs, so we will add the logic required to send the logs of the missing services. 

We will implement the _log to stdout and redirect  to `logger` pattern_ whenever is possible.
## Implementation in logsearch bosh release

We want to implement the same idea in all the graphite and statsd services.

For that we we add several properties: `<service>.log_to_syslog`. When true, we redirect the stdout and stderr in the ctl script into syslog following the standard vcap pattern, in addition to files.

In the case of carbon, in order to get the logs sent to `stdout`, we add the option `--debug`.

In the case of `graphite-web`, we shell out the Log directives to stream the logs to `logger`.
## How to review?

Enable the `*.log_to_syslog` and deploy. Logs should be sent to syslog. 

If metron agent is installed locally, the logs will be redirected to metron agent the loggregrator.
## Open questions

This PR is open to debate for several open questions:
- Is OK to add a specific property to enable this feature for each service? Shall we use one unique property? or should this be enabled by default?
- Is the tag `vcap.*` the most appropriate one? This is not a CF official release. But the generic tag vcap.\* might be handy to refer to a service deployed with bosh.
- `tee` and `logger` run as `root` for `statsd` and `carbon` Is that fine?
